### PR TITLE
Reorganize home page to move weekly posts to sidebar

### DIFF
--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -2,6 +2,7 @@
 common-css:
   - "/assets/css/bootstrap-social.css"
   - "/assets/css/beautifuljekyll.css"
+  - "/assets/css/weekly-sidebar.css"
 common-ext-css:
   - href: "https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/css/bootstrap.min.css"
     sri: "sha384-Vkoo8x4CGsO3+Hhxv8T/Q5PaXtkKtu6ug5TOeNV6gBiFeWPGFN9MuhOf23Q9Ifjh"

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -1,122 +1,165 @@
 ---
-layout: page
+layout: base
 ---
 
-{{ content }}
+{% include header.html type="page" %}
 
-{% assign posts = paginator.posts | default: site.posts %}
+<main class="container-md">
+  <div class="row">
+    <div class="col-xl-8 offset-xl-2 col-lg-10 offset-lg-1">
+      {{ content }}
+    </div>
+  </div>
 
-<!-- role="list" needed so that `list-style: none` in Safari doesn't remove the list semantics -->
-<ul class="posts-list list-unstyled" role="list">
-  {% for post in posts %}
-  <li class="post-preview">
-    <article>
+  {% assign posts = paginator.posts | default: site.posts %}
+  {% assign regular_posts = posts | where_exp: "item", "item.tags contains 'weekly-whats-up' == false" %}
+  {% assign weekly_posts = posts | where: "tags", "weekly-whats-up" %}
 
-      {%- capture thumbnail -%}
-        {% if post.thumbnail-img %}
-          {{ post.thumbnail-img }}
-        {% elsif post.cover-img %}
-          {% if post.cover-img.first %}
-            {{ post.cover-img[0].first.first }}
-          {% else %}
-            {{ post.cover-img }}
-          {% endif %}
-        {% else %}
+  <div class="row">
+    <!-- Regular Posts - Main Column -->
+    <div class="col-lg-8">
+      <h3>Latest Posts</h3>
+      <!-- role="list" needed so that `list-style: none` in Safari doesn't remove the list semantics -->
+      <ul class="posts-list list-unstyled" role="list">
+        {% for post in regular_posts limit: 10 %}
+        <li class="post-preview">
+          <article>
+
+            {%- capture thumbnail -%}
+              {% if post.thumbnail-img %}
+                {{ post.thumbnail-img }}
+              {% elsif post.cover-img %}
+                {% if post.cover-img.first %}
+                  {{ post.cover-img[0].first.first }}
+                {% else %}
+                  {{ post.cover-img }}
+                {% endif %}
+              {% else %}
+              {% endif %}
+            {% endcapture %}
+            {% assign thumbnail=thumbnail | strip %}
+
+            {% if site.feed_show_excerpt == false %}
+            {% if thumbnail != "" %}
+            <div class="post-image post-image-normal">
+              <a href="{{ post.url | absolute_url }}" aria-label="Thumbnail">
+                <img src="{{ thumbnail | absolute_url }}" alt="Post thumbnail">
+              </a>
+            </div>
+            {% endif %}
+            {% endif %}
+
+            <a href="{{ post.url | absolute_url }}">
+              <h2 class="post-title">{{ post.title | strip_html }}</h2>
+
+              {% if post.subtitle %}
+                <h3 class="post-subtitle">
+                {{ post.subtitle | strip_html }}
+                </h3>
+              {% endif %}
+            </a>
+
+            {% if post.author %}
+              <span>By <strong>{{ post.author | strip_html }}</strong></span>
+            {% endif %}
+            <p class="post-meta">
+              {% assign date_format = site.date_format | default: "%B %-d, %Y" %}
+              Posted on {{ post.date | date: date_format }}
+            </p>
+
+            {% if thumbnail != "" %}
+            <div class="post-image post-image-small">
+              <a href="{{ post.url | absolute_url }}" aria-label="Thumbnail">
+                <img src="{{ thumbnail | absolute_url }}" alt="Post thumbnail">
+              </a>
+            </div>
+            {% endif %}
+
+            {% unless site.feed_show_excerpt == false %}
+            {% if thumbnail != "" %}
+            <div class="post-image post-image-short">
+              <a href="{{ post.url | absolute_url }}" aria-label="Thumbnail">
+                <img src="{{ thumbnail | absolute_url }}" alt="Post thumbnail">
+              </a>
+            </div>
+            {% endif %}
+
+            <div class="post-entry">
+              {% assign excerpt_length = site.excerpt_length | default: 50 %}
+              {{ post.excerpt | strip_html | truncatewords: excerpt_length }}
+              {% assign excerpt_word_count = post.excerpt | number_of_words %}
+              {% if post.content != post.excerpt or excerpt_word_count > excerpt_length %}
+                <a href="{{ post.url | absolute_url }}" class="post-read-more">[Read&nbsp;More]</a>
+              {% endif %}
+            </div>
+            {% endunless %}
+
+            {% if site.feed_show_tags != false and post.tags.size > 0 %}
+            <div class="blog-tags">
+              <span>Tags:</span>
+              <!-- role="list" needed so that `list-style: none` in Safari doesn't remove the list semantics -->
+              <ul class="d-inline list-inline" role="list">
+                {% for tag in post.tags %}
+                <li class="list-inline-item">
+                  <a href="{{ '/tags' | absolute_url }}#{{- tag -}}">{{- tag -}}</a>
+                </li>
+                {% endfor %}
+              </ul>
+            </div>
+            {% endif %}
+
+          </article>
+        </li>
+        {% endfor %}
+      </ul>
+
+      {% if paginator.total_pages > 1 %}
+      <ul class="pagination main-pager">
+        {% if paginator.previous_page %}
+        <li class="page-item previous">
+          <a class="page-link" href="{{ paginator.previous_page_path | absolute_url }}">
+            <i class="fas fa-arrow-left" alt="Newer Posts"></i>
+            <span class="d-none d-sm-inline-block">Newer Posts</span>
+          </a>
+        </li>
         {% endif %}
-      {% endcapture %}
-      {% assign thumbnail=thumbnail | strip %}
-
-      {% if site.feed_show_excerpt == false %}
-      {% if thumbnail != "" %}
-      <div class="post-image post-image-normal">
-        <a href="{{ post.url | absolute_url }}" aria-label="Thumbnail">
-          <img src="{{ thumbnail | absolute_url }}" alt="Post thumbnail">
-        </a>
-      </div>
-      {% endif %}
-      {% endif %}
-
-      <a href="{{ post.url | absolute_url }}">
-        <h2 class="post-title">{{ post.title | strip_html }}</h2>
-
-        {% if post.subtitle %}
-          <h3 class="post-subtitle">
-          {{ post.subtitle | strip_html }}
-          </h3>
+        {% if paginator.next_page %}
+        <li class="page-item next">
+          <a class="page-link" href="{{ paginator.next_page_path | absolute_url }}">
+            <span class="d-none d-sm-inline-block">Older Posts</span>
+            <i class="fas fa-arrow-right" alt="Older Posts"></i>
+          </a>
+        </li>
         {% endif %}
-      </a>
-
-      {% if post.author %}
-        <span>By <strong>{{ post.author | strip_html }}</strong></span>
+      </ul>
       {% endif %}
-      <p class="post-meta">
-        {% assign date_format = site.date_format | default: "%B %-d, %Y" %}
-        Posted on {{ post.date | date: date_format }}
-      </p>
+    </div>
 
-      {% if thumbnail != "" %}
-      <div class="post-image post-image-small">
-        <a href="{{ post.url | absolute_url }}" aria-label="Thumbnail">
-          <img src="{{ thumbnail | absolute_url }}" alt="Post thumbnail">
-        </a>
-      </div>
-      {% endif %}
-
-      {% unless site.feed_show_excerpt == false %}
-      {% if thumbnail != "" %}
-      <div class="post-image post-image-short">
-        <a href="{{ post.url | absolute_url }}" aria-label="Thumbnail">
-          <img src="{{ thumbnail | absolute_url }}" alt="Post thumbnail">
-        </a>
-      </div>
-      {% endif %}
-
-      <div class="post-entry">
-        {% assign excerpt_length = site.excerpt_length | default: 50 %}
-        {{ post.excerpt | strip_html | truncatewords: excerpt_length }}
-        {% assign excerpt_word_count = post.excerpt | number_of_words %}
-        {% if post.content != post.excerpt or excerpt_word_count > excerpt_length %}
-          <a href="{{ post.url | absolute_url }}" class="post-read-more">[Read&nbsp;More]</a>
-        {% endif %}
-      </div>
-      {% endunless %}
-
-      {% if site.feed_show_tags != false and post.tags.size > 0 %}
-      <div class="blog-tags">
-        <span>Tags:</span>
-        <!-- role="list" needed so that `list-style: none` in Safari doesn't remove the list semantics -->
-        <ul class="d-inline list-inline" role="list">
-          {% for tag in post.tags %}
-          <li class="list-inline-item">
-            <a href="{{ '/tags' | absolute_url }}#{{- tag -}}">{{- tag -}}</a>
+    <!-- Weekly Posts - Sidebar -->
+    <div class="col-lg-4">
+      <div class="weekly-posts-sidebar">
+        <h4 class="text-muted">Weekly What's Up</h4>
+        <ul class="list-unstyled weekly-posts-list" role="list">
+          {% for post in weekly_posts limit: 8 %}
+          <li class="weekly-post-item mb-3">
+            <a href="{{ post.url | absolute_url }}" class="weekly-post-link">
+              <h6 class="weekly-post-title mb-1">{{ post.title | strip_html }}</h6>
+              <small class="text-muted">
+                {% assign date_format = "%b %-d, %Y" %}
+                {{ post.date | date: date_format }}
+              </small>
+            </a>
           </li>
           {% endfor %}
         </ul>
+        {% if weekly_posts.size > 8 %}
+        <p class="text-center">
+          <a href="{{ '/tags' | absolute_url }}#weekly-whats-up" class="text-muted">
+            <small>View all weekly posts →</small>
+          </a>
+        </p>
+        {% endif %}
       </div>
-      {% endif %}
-
-    </article>
-  </li>
-  {% endfor %}
-</ul>
-
-{% if paginator.total_pages > 1 %}
-<ul class="pagination main-pager">
-  {% if paginator.previous_page %}
-  <li class="page-item previous">
-    <a class="page-link" href="{{ paginator.previous_page_path | absolute_url }}">
-      <i class="fas fa-arrow-left" alt="Newer Posts"></i>
-      <span class="d-none d-sm-inline-block">Newer Posts</span>
-    </a>
-  </li>
-  {% endif %}
-  {% if paginator.next_page %}
-  <li class="page-item next">
-    <a class="page-link" href="{{ paginator.next_page_path | absolute_url }}">
-      <span class="d-none d-sm-inline-block">Older Posts</span>
-      <i class="fas fa-arrow-right" alt="Older Posts"></i>
-    </a>
-  </li>
-  {% endif %}
-</ul>
-{% endif %}
+    </div>
+  </div>
+</main>

--- a/assets/css/weekly-sidebar.css
+++ b/assets/css/weekly-sidebar.css
@@ -1,0 +1,75 @@
+---
+layout: null
+---
+
+/* Weekly Posts Sidebar Styling */
+.weekly-posts-sidebar {
+  background-color: #f8f9fa;
+  border-left: 3px solid #dee2e6;
+  padding: 1.5rem;
+  border-radius: 0.375rem;
+  margin-top: 1rem;
+}
+
+.weekly-posts-sidebar h4 {
+  font-family: var(--header-font, 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif);
+  font-weight: 600;
+  margin-bottom: 1rem;
+  font-size: 1.1rem;
+}
+
+.weekly-posts-list {
+  margin-bottom: 0;
+}
+
+.weekly-post-item {
+  padding: 0.75rem 0;
+  border-bottom: 1px solid #e9ecef;
+}
+
+.weekly-post-item:last-child {
+  border-bottom: none;
+  margin-bottom: 0 !important;
+}
+
+.weekly-post-link {
+  text-decoration: none;
+  display: block;
+  transition: opacity 0.2s ease-in-out;
+}
+
+.weekly-post-link:hover {
+  text-decoration: none;
+  opacity: 0.8;
+}
+
+.weekly-post-title {
+  font-size: 0.95rem;
+  font-weight: 500;
+  line-height: 1.3;
+  color: var(--text-col, #404040);
+  font-family: var(--header-font, 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif);
+}
+
+.weekly-post-link:hover .weekly-post-title {
+  color: var(--link-col, #008AFF);
+}
+
+/* Responsive adjustments */
+@media (max-width: 991.98px) {
+  .weekly-posts-sidebar {
+    margin-top: 2rem;
+    border-left: none;
+    border-top: 3px solid #dee2e6;
+  }
+}
+
+@media (max-width: 575.98px) {
+  .weekly-posts-sidebar {
+    padding: 1rem;
+  }
+  
+  .weekly-post-title {
+    font-size: 0.9rem;
+  }
+}


### PR DESCRIPTION
- Modified home layout to separate regular posts from weekly-whats-up posts
- Created two-column responsive layout with main posts and weekly sidebar
- Added custom CSS styling for weekly posts sidebar
- Weekly posts are now de-emphasized while still accessible